### PR TITLE
Use ESLint instead of Standard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+	"extends": "standard",
+	"rules": {
+		"indent": ["error", "tab"],
+		"no-tabs": "off"
+	}
+}

--- a/commands/dev/test.js
+++ b/commands/dev/test.js
@@ -1,21 +1,21 @@
 exports.pre = (client, message) => {
-  console.log('Test command run by ' + message.author.username)
+	console.log('Test command run by ' + message.author.username)
 }
 
 exports.run = (client, message, args, pre) => {
-  let initialText = args.echo || 'Test message.'
-  let text = ''
-  for (let i = 0; i < args.repeat; i++) text += initialText
-  message.author.send(text).catch(console.error)
+	let initialText = args.echo || 'Test message.'
+	let text = ''
+	for (let i = 0; i < args.repeat; i++) text += initialText
+	message.author.send(text).catch(console.error)
 }
 
 exports.post = (client, message, result) => {
-  console.log('Test command complete!')
+	console.log('Test command complete!')
 }
 
 exports.help = {
-  name: ['test'],
-  group: 'dev',
-  description: 'A test command.',
-  args: '<echo:string> [repeat:integer=1]'
+	name: ['test'],
+	group: 'dev',
+	description: 'A test command.',
+	args: '<echo:string> [repeat:integer=1]'
 }

--- a/config-example.json
+++ b/config-example.json
@@ -1,6 +1,6 @@
 {
-  "token": "bot-token",
-  "prefix": "?",
-  "procName": "Discord_Bots",
-  "authors": ["Mundane"]
+	"token": "bot-token",
+	"prefix": "?",
+	"procName": "Discord_Bots",
+	"authors": ["Mundane"]
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "discord.js": "^11.4.0"
   },
   "devDependencies": {
-    "standard": "*"
+    "eslint": "^5.6.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0"
   }
 }

--- a/src/classes/Handler.js
+++ b/src/classes/Handler.js
@@ -4,73 +4,73 @@ const { ArgumentError } = require('../errors')
 const Config = require('../../config')
 
 class Handler {
-  constructor (client) {
-    let _self = this
-    this.commands = { }
+	constructor (client) {
+		let _self = this
+		this.commands = { }
 
-    this.client = client
-    client.on('message', message => _self.message(_self, message))
-    client.on('guildMemberAdd', member => _self.guildMemberAdd(_self, member))
+		this.client = client
+		client.on('message', message => _self.message(_self, message))
+		client.on('guildMemberAdd', member => _self.guildMemberAdd(_self, member))
 
-    this.loadCommands()
-  }
+		this.loadCommands()
+	}
 
-  loadCommands () {
-    let groups = FS.readdirSync('./commands')
-    let commands
-    let command
-    let count = { groups: 0, commands: 0 }
+	loadCommands () {
+		let groups = FS.readdirSync('./commands')
+		let commands
+		let command
+		let count = { groups: 0, commands: 0 }
 
-    groups.forEach(group => {
-      this.commands[group] = { }
-      commands = FS.readdirSync(`./commands/${group}`)
-      commands.forEach(cmd => {
-        command = require(`../../commands/${group}/${cmd}`)
-        command.help.name.forEach(name => {
-          if (Object.keys(this.commands[group]).includes(name)) {
-            console.warn(`${name} already exists; skipping...`)
-          } else {
-            console.info(`Loaded command ${name}.`)
-            this.commands[group][name] = command
-          }
-        })
-        count.commands++
-      })
-      count.groups++
-    })
-    console.info(`Done! ${count.commands} commands loaded across ${count.groups} groups.`)
-  }
+		groups.forEach(group => {
+			this.commands[group] = { }
+			commands = FS.readdirSync(`./commands/${group}`)
+			commands.forEach(cmd => {
+				command = require(`../../commands/${group}/${cmd}`)
+				command.help.name.forEach(name => {
+					if (Object.keys(this.commands[group]).includes(name)) {
+						console.warn(`${name} already exists; skipping...`)
+					} else {
+						console.info(`Loaded command ${name}.`)
+						this.commands[group][name] = command
+					}
+				})
+				count.commands++
+			})
+			count.groups++
+		})
+		console.info(`Done! ${count.commands} commands loaded across ${count.groups} groups.`)
+	}
 
-  start () {
-    this.client.login(Config.token)
-    process.title = Config.procName
-  }
+	start () {
+		this.client.login(Config.token)
+		process.title = Config.procName
+	}
 
-  message (_self, message) {
-    // Non-handling cases
-    if (message.author.bot) return
-    if (message.channel.type !== 'text') return
-    if (message.content.substring(0, Config.prefix.length) !== Config.prefix) return
+	message (_self, message) {
+		// Non-handling cases
+		if (message.author.bot) return
+		if (message.channel.type !== 'text') return
+		if (message.content.substring(0, Config.prefix.length) !== Config.prefix) return
 
-    let content = message.content.split(' ')
-    let name = content.splice(0, 1)[0].substring(Config.prefix.length)
-    let cmds = { }
-    Object.values(_self.commands).forEach(c => { cmds = { ...cmds, ...c } })
-    if (!cmds.hasOwnProperty(name)) return console.warn(`Command ${name} not found.`)
-    let command = cmds[name]
-    try {
-      let pre = command.pre(this, message)
-      let result = command.run(this, message, Arguments.parse(command.help.args, content.join(' ')), pre)
-      command.post(this, message, result)
-    } catch (e) {
-      if (e instanceof ArgumentError) {
-        message.reply(e.message).then(m => m.delete(8000)).catch(console.error)
-      } else throw e
-    }
-  }
+		let content = message.content.split(' ')
+		let name = content.splice(0, 1)[0].substring(Config.prefix.length)
+		let cmds = { }
+		Object.values(_self.commands).forEach(c => { cmds = { ...cmds, ...c } })
+		if (!cmds.hasOwnProperty(name)) return console.warn(`Command ${name} not found.`)
+		let command = cmds[name]
+		try {
+			let pre = command.pre(this, message)
+			let result = command.run(this, message, Arguments.parse(command.help.args, content.join(' ')), pre)
+			command.post(this, message, result)
+		} catch (e) {
+			if (e instanceof ArgumentError) {
+				message.reply(e.message).then(m => m.delete(8000)).catch(console.error)
+			} else throw e
+		}
+	}
 
-  guildMemberAdd (_self, member) {
+	guildMemberAdd (_self, member) {
 
-  }
+	}
 }
 module.exports = Handler

--- a/src/classes/index.js
+++ b/src/classes/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  Bot: require('./Bot'),
-  Config: require('./Config')
+	Bot: require('./Bot'),
+	Config: require('./Config')
 }

--- a/src/errors/ArgumentError.js
+++ b/src/errors/ArgumentError.js
@@ -1,12 +1,12 @@
 class ArgumentError extends Error {
-  constructor (format, value) {
-    if (format.required && (!value || value.length === 0)) {
-      super(`${format.name} is a required argument.`)
-    } else if (!format.type.includes(typeof value)) {
-      super(`${format.name} must be a(n) ${format.type[0]}.`)
-    } else {
-      super(`${format.name} was given an incorrect value.`)
-    }
-  }
+	constructor (format, value) {
+		if (format.required && (!value || value.length === 0)) {
+			super(`${format.name} is a required argument.`)
+		} else if (!format.type.includes(typeof value)) {
+			super(`${format.name} must be a(n) ${format.type[0]}.`)
+		} else {
+			super(`${format.name} was given an incorrect value.`)
+		}
+	}
 }
 module.exports = ArgumentError

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ArgumentError: require('./ArgumentError')
+	ArgumentError: require('./ArgumentError')
 }

--- a/src/utility/arguments/Arguments.js
+++ b/src/utility/arguments/Arguments.js
@@ -4,90 +4,90 @@ const Types = require('./Types')
 const { ArgumentError } = require('../../errors')
 
 class Arguments {
-  static parse (format, raw) {
-    // Only parse valid format strings
-    if (!format || (format[0] !== '<' && format[0] !== '[]')) return
+	static parse (format, raw) {
+		// Only parse valid format strings
+		if (!format || (format[0] !== '<' && format[0] !== '[]')) return
 
-    // Will contain argument map for final return
-    let args = { }
-    // Will hold argument format objects as arguments are parsed
-    let argFormats = [ ]
+		// Will contain argument map for final return
+		let args = { }
+		// Will hold argument format objects as arguments are parsed
+		let argFormats = [ ]
 
-    // Grab all the relevant information from the argument format string
-    format.split(' ').forEach(arg => {
-      let [, name, type, _default] = ArgumentRegex.exec(arg)
-      // Temporarily hold some information for each argument's parse
-      argFormats.push({ name: name,
-        type: type[0] === '?'
-          ? type.substring(1, type.length - 1)
-          : type,
-        required: arg[0] === '<',
-        default: _default })
-    })
+		// Grab all the relevant information from the argument format string
+		format.split(' ').forEach(arg => {
+			let [, name, type, _default] = ArgumentRegex.exec(arg)
+			// Temporarily hold some information for each argument's parse
+			argFormats.push({ name: name,
+				type: type[0] === '?'
+					? type.substring(1, type.length - 1)
+					: type,
+				required: arg[0] === '<',
+				default: _default })
+		})
 
-    // Parse individual arguments, returning a result object
-    let result
-    let repeat
-    let passed = raw.split(' ')
-    argFormats.forEach((format, i) => {
-      do {
-        repeat = false
-        result = Arguments.parseArgument(passed[i], format)
-        if (!result.success) {
-          /*
+		// Parse individual arguments, returning a result object
+		let result
+		let repeat
+		let passed = raw.split(' ')
+		argFormats.forEach((format, i) => {
+			do {
+				repeat = false
+				result = Arguments.parseArgument(passed[i], format)
+				if (!result.success) {
+					/*
             If the argument was optional, perhaps this value is intended to be
             the next argument's
           */
-          if (!format.required && argFormats[i + 1] && argFormats[i + 1].type.includes(typeof passed[i])) {
-            repeat = true
-            i++
-          } else {
-            throw new ArgumentError(format, passed[i])
-          }
-        // Merge the new argument into the argument map
-        } else args = { ...args, ...result.argument }
-      } while (repeat)
-    })
+					if (!format.required && argFormats[i + 1] && argFormats[i + 1].type.includes(typeof passed[i])) {
+						repeat = true
+						i++
+					} else {
+						throw new ArgumentError(format, passed[i])
+					}
+					// Merge the new argument into the argument map
+				} else args = { ...args, ...result.argument }
+			} while (repeat)
+		})
 
-    return args
-  }
+		return args
+	}
 
-  static parseArgument (value, format) {
-    let result = { argument: { }, success: false }
+	static parseArgument (value, format) {
+		let result = { argument: { }, success: false }
 
-    // Check nullable argument type and assign default
-    // If no default is provided, let it return false
-    if (!value || value.length === 0) {
-      if (format.default) value = format.default
-      else return result
-    }
-    // Parse values to correct types; see Types.js
-    if (Types.String.includes(format.type)) {
-      result.argument[format.name] = value
-      result.success = true
-    } else if (Types.Integer.includes(format.type)) {
-      if (!isNaN(value)) {
-        result.argument[format.name] = parseInt(value)
-        result.success = true
-      }
-    } else if (Types.Float.includes(format.type)) {
-      if (!isNaN(value)) {
-        result.argument[format] = parseFloat(value)
-        result.success = true
-      }
-    } else if (Types.Boolean.includes(format.type)) {
-      let val = value.toLowerCase()
-      if (val === 'true' || val === '1' || val === 'yes' || val === 'y') {
-        result.argument[format.name] = true
-        result.success = true
-      } else if (val === 'false' || val === '0' || val === 'no' || val === 'n') {
-        result.argument[format.name] = false
-        result.success = true
-      }
-    }
+		// Check nullable argument type and assign default
+		// If no default is provided, let it return false
+		if (!value || value.length === 0) {
+			if (format.default) value = format.default
+			else return result
+		}
+		// Parse values to correct types; see Types.js
+		if (Types.String.includes(format.type)) {
+			result.argument[format.name] = value
+			result.success = true
+		} else if (Types.Integer.includes(format.type)) {
+			if (!isNaN(value)) {
+				result.argument[format.name] = parseInt(value)
+				result.success = true
+			}
+		} else if (Types.Float.includes(format.type)) {
+			if (!isNaN(value)) {
+				result.argument[format] = parseFloat(value)
+				result.success = true
+			}
+		} else if (Types.Boolean.includes(format.type)) {
+			let val = value.toLowerCase()
+			if (val === 'true' || val === '1' || val === 'yes' || val === 'y') {
+				result.argument[format.name] = true
+				result.success = true
+			} else if (val === 'false' || val === '0' || val === 'no' || val === 'n') {
+				result.argument[format.name] = false
+				result.success = true
+			}
+		}
 
-    return result
-  }
+		return result
+	}
 }
 
 module.exports = Arguments

--- a/src/utility/arguments/Types.js
+++ b/src/utility/arguments/Types.js
@@ -1,19 +1,19 @@
 module.exports = {
-  String: ['string'],
-  Integer: ['integer', 'number'],
-  Float: ['float', 'number'],
-  Boolean: ['boolean']
+	String: ['string'],
+	Integer: ['integer', 'number'],
+	Float: ['float', 'number'],
+	Boolean: ['boolean']
 }
 
 /*
-    This looks like a very strange enum and it is, but for good reason.
-    There are only 3 DataTypes in JavaScript, if you can call them that: String,
-  Number and Boolean, where a Number is any real number. Thus telling the
-  difference between an integer and a float is a bit tricky, since `typeof` will
-  only tell us that it is a Number of some description.
-    The way I get around this without creating a whole new case for integers and
-  floats is by checking to see if `type.includes(typeof value)`. This way it is
-  still possible to tell an integer from a float since
-  `Types.Integer !== Types.Float` have different arrays, whilst both being able
-  to be compared to the Number type.
+		This looks like a very strange enum and it is, but for good reason.
+		There are only 3 DataTypes in JavaScript, if you can call them that: String,
+	Number and Boolean, where a Number is any real number. Thus telling the
+	difference between an integer and a float is a bit tricky, since `typeof` will
+	only tell us that it is a Number of some description.
+		The way I get around this without creating a whole new case for integers and
+	floats is by checking to see if `type.includes(typeof value)`. This way it is
+	still possible to tell an integer from a float since
+	`Types.Integer !== Types.Float` have different arrays, whilst both being able
+	to be compared to the Number type.
 */

--- a/src/utility/index.js
+++ b/src/utility/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  Arguments: require('./arguments/Arguments'),
-  Types: require('./arguments/Types')
+	Arguments: require('./arguments/Arguments'),
+	Types: require('./arguments/Types')
 }


### PR DESCRIPTION
I've removed the Standard linter and instead added ESLint directly, with the eslint-config-standard configuration. The ruleset has been modified to use tabs instead of spaces for indentation.