### PR TITLE
UNIX-style command arguments

### DIFF
--- a/commands/dev/testunix.js
+++ b/commands/dev/testunix.js
@@ -1,0 +1,56 @@
+const UnixArguments = require('../../src/utility/arguments/UnixArguments.js')
+
+exports.pre = async (client, message) => {
+	console.log('Test command (UNIX) run by ' + message.author.username)
+}
+
+exports.run = async (client, message, args, pre) => {
+	let initialText = args.echo
+	let text = ''
+	for (let i = 0; i < args.repeat; i++) text += initialText
+	return message.author.send(text)
+}
+
+exports.post = async (client, message, result) => {
+	console.log('Test command (UNIX) complete!')
+}
+
+/*
+	This object is mostly equivalent to yargs-parser's options object (see: https://github.com/yargs/yargs-parser#requireyargs-parserargs-opts),
+	with a few additions used by the internal parser wrapper:
+
+	Although yargs-parser only knows numbers, here "integer" and "float" are also supported types.
+
+	Similarly, "user" and "channel" are supported types for user and channel mentions, respectively. These allow both mentions and the IDs
+	directly, and the parser will convert those into the IDs. If nothing resembling an ID is passed, false is returned.
+	(Note: There is no guarantee that the IDs actually exist, only that they look like valid IDs. Validation in the command is required.)
+
+	Passing an object with a "description" property as a default value will treat it not as a literal value, but a description of a default value
+	that's computed at runtime. It is the command implementer's responsibility to actually compute and set that value, as the parser cannot do that.
+
+	Additional supported fields are "required" and "exclusive".
+	- "required" is an array of strings listing all arguments that must be present. Any argument not listed is assumed to be optional.
+	- "exclusive" is an array of arrays of strings, listing groups of mutually exclusive arguments. Listing one or more arguments of a
+	group as required will mean the entire group is required.
+
+	Lastly, the --help argument is reserved. If it (or any alias of it) is used, the command is not executed, and its usage information is
+	displayed instead.
+*/
+exports.yargsOpts = {
+	alias: {
+		help: ['h']
+	},
+	string: ['echo'],
+	integer: ['repeat'],
+	default: {
+		repeat: 1
+	},
+	required: ['echo']
+}
+
+exports.help = {
+	name: ['testunix'],
+	group: 'dev',
+	description: 'A test command with UNIX-style arguments.',
+	args: UnixArguments.generateUsage(exports.yargsOpts)
+}

--- a/commands/dev/unixargs.js
+++ b/commands/dev/unixargs.js
@@ -1,0 +1,34 @@
+const UnixArguments = require('../../src/utility/arguments/UnixArguments.js')
+
+exports.pre = async (client, message) => {
+	console.log('UNIX argument parser test command run by ' + message.author.username)
+}
+
+exports.run = async (client, message, args, pre) => {
+	let parsed
+	try {
+		parsed = UnixArguments.parse(JSON.parse(args.opts), message.content.slice('?unixargs'.length).trim())
+	} catch (err) {
+		return message.channel.send('Error:```\n' + err + '\n```')
+	}
+	delete parsed.opts
+	return message.channel.send('Options:```\n' + JSON.stringify(JSON.parse(args.opts), null, '\t') + '\n```\nParsed:```\n' + JSON.stringify(parsed, null, '\t') + '\n```')
+}
+
+exports.post = async (client, message, result) => {
+	console.log('UNIX argument parser test command complete!')
+}
+
+exports.yargsOpts = {
+	string: ['opts'],
+	default: {
+		opts: '{}'
+	}
+}
+
+exports.help = {
+	name: ['unixargs'],
+	group: 'dev',
+	description: 'A command to test the UNIX argument parsing.',
+	args: UnixArguments.generateUsage(exports.yargsOpts)
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "homepage": "https://github.com/Mundayne/Discord_Bot#readme",
   "dependencies": {
-    "discord.js": "^11.4.0"
+    "discord.js": "^11.4.0",
+    "yargs-parser": "^10.1.0"
   },
   "devDependencies": {
     "eslint": "^5.6.0",

--- a/src/classes/Handler.js
+++ b/src/classes/Handler.js
@@ -1,6 +1,6 @@
 const FS = require('fs')
 const { Arguments, UnixArguments } = require('../utility')
-const { ArgumentError, UnixArgumentError } = require('../errors')
+const { ArgumentError, UnixArgumentError, UnixHelpError } = require('../errors')
 const Config = require('../../config')
 
 class Handler {
@@ -68,6 +68,8 @@ class Handler {
 				message.reply(e.message).then(m => m.delete(8000)).catch(console.error)
 			} else if (e instanceof UnixArgumentError) {
 				message.reply(e.message).then(m => m.delete(8000)).catch(console.error)
+			} else if (e instanceof UnixHelpError) {
+				message.channel.send(`${'```'}\nUsage:\n${Config.prefix}${name} ${command.help.args}\n${'```'}`).catch(console.error)
 			} else {
 				console.error(`Error during command "${name}":`)
 				console.error(e)

--- a/src/errors/UnixArgumentError.js
+++ b/src/errors/UnixArgumentError.js
@@ -1,0 +1,30 @@
+class UnixArgumentError extends Error {
+	constructor (errData) {
+		switch (errData.error) {
+		case 'exclusive': {
+			super(`Arguments ${errData.args.map(e => `"${e}"`).join(', ')} are mutually exclusive.`)
+			break
+		}
+		case 'narg': {
+			super(`Argument "${errData.args[0]}" needs ${errData.expected} values.`)
+			break
+		}
+		case 'required': {
+			if (errData.args.length === 1) {
+				super(`Argument "${errData.args[0]}" is required.`)
+			} else {
+				super(`One of ${errData.args.map(e => `"${e}"`).join(', ')} is required.`)
+			}
+			break
+		}
+		case 'type': {
+			super(`Argument "${errData.args[0]}" must be of type ${errData.expected}.`)
+			break
+		}
+		default: super('An unknown error occurred.')
+		}
+		this.name = 'UnixArgumentError'
+	}
+}
+
+module.exports = UnixArgumentError

--- a/src/errors/UnixHelpError.js
+++ b/src/errors/UnixHelpError.js
@@ -1,0 +1,8 @@
+class UnixHelpError extends Error {
+	constructor () {
+		super('Help argument has been used.')
+		this.name = 'UnixHelpError'
+	}
+}
+
+module.exports = UnixHelpError

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-	ArgumentError: require('./ArgumentError')
+	ArgumentError: require('./ArgumentError'),
+	UnixArgumentError: require('./UnixArgumentError')
 }

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,4 +1,5 @@
 module.exports = {
 	ArgumentError: require('./ArgumentError'),
-	UnixArgumentError: require('./UnixArgumentError')
+	UnixArgumentError: require('./UnixArgumentError'),
+	UnixHelpError: require('./UnixHelpError')
 }

--- a/src/utility/arguments/UnixArguments.js
+++ b/src/utility/arguments/UnixArguments.js
@@ -225,7 +225,7 @@ class UnixArguments {
 		for (let arg of (opts.integer || [])) {
 			let argValues = Array.isArray(parsed[arg]) ? parsed[arg] : [parsed[arg]]
 			argValues.forEach(e => {
-				if (Number.isNaN(e) || e !== Math.trunc(e)) {
+				if (Number.isNaN(e) || (e !== undefined && e !== Math.trunc(e))) {
 					throw new UnixArgumentError({ error: 'type', args: [arg], expected: 'integer' })
 				}
 			})

--- a/src/utility/arguments/UnixArguments.js
+++ b/src/utility/arguments/UnixArguments.js
@@ -1,0 +1,172 @@
+const yargsParser = require('yargs-parser')
+
+const { UnixArgumentError } = require('../../errors')
+
+class UnixArguments {
+	/**
+	 * Parses UNIX-style arguments for a command
+	 * @param {Object} opts Parser options
+	 * @param {String} raw Message content after the command
+	 * @returns {Object} Object containing the parsed arguments
+	 */
+	static parse (opts, raw) {
+		// we will be modifiying the options object, so make a copy to work on
+		let optsCopy = JSON.parse(JSON.stringify(opts))
+
+		// normalize "integer" and "float" to "number"
+		if (optsCopy.integer) {
+			optsCopy.number = optsCopy.number || []
+			for (let item of optsCopy.integer) {
+				optsCopy.number.push(item)
+			}
+		}
+		if (optsCopy.float) {
+			optsCopy.number = optsCopy.number || []
+			for (let item of optsCopy.float) {
+				optsCopy.number.push(item)
+			}
+		}
+
+		// normalize "user" and "channel" to "string", and add coercion functions
+		if (optsCopy.user) {
+			optsCopy.coerce = optsCopy.coerce || {}
+			optsCopy.string = optsCopy.string || []
+			for (let item of optsCopy.user) {
+				optsCopy.string.push(item)
+				optsCopy.coerce[item] = UnixArguments._coerceUser
+			}
+		}
+		if (optsCopy.channel) {
+			optsCopy.coerce = optsCopy.coerce || {}
+			optsCopy.string = optsCopy.string || []
+			for (let item of optsCopy.channel) {
+				optsCopy.string.push(item)
+				optsCopy.coerce[item] = UnixArguments._coerceChannel
+			}
+		}
+
+		// remove non-literal defaults
+		if (optsCopy.default) {
+			for (let key in optsCopy.default) {
+				if (optsCopy.default[key].description) optsCopy.default[key] = undefined
+			}
+		}
+
+		// use yargs-parser for main parsing
+		let parsed = yargsParser(raw, optsCopy)
+
+		// TODO if "help" is set, abort and print usage
+
+		// validate parsing results (types and required/exclusive arguments)
+		let required = opts.required || []
+		let exclusive = opts.exclusive || []
+		let requiredExclusive = []
+		let optionalExclusive = []
+
+		// sort exclusive groups into required and optional
+		for (let item of exclusive) {
+			if (item.some(e => required.includes(e))) {
+				requiredExclusive.push(item)
+			} else {
+				optionalExclusive.push(item)
+			}
+		}
+		// remove arguments in required exclusive groups from the "required" list (since they're checked seperately)
+		for (let item of requiredExclusive) {
+			for (let arg of item) {
+				let index
+				if ((index = required.findIndex(e => e === arg)) !== -1) {
+					required.splice(index, 1)
+				}
+			}
+		}
+
+		// validate exclusive groups
+		for (let item of requiredExclusive) {
+			let count = 0
+			for (let arg of item) {
+				count += Number(parsed[arg] !== undefined)
+			}
+			if (count > 1) {
+				throw new UnixArgumentError({ error: 'exclusive', args: item })
+			} else if (count === 0) {
+				throw new UnixArgumentError({ error: 'required', args: item })
+			}
+		}
+		for (let item of optionalExclusive) {
+			let count = 0
+			for (let arg of item) {
+				count += Number(parsed[arg] !== undefined)
+			}
+			if (count > 1) {
+				throw new UnixArgumentError({ error: 'exclusive', args: item })
+			}
+		}
+
+		// validate required arguments
+		for (let item of required) {
+			if (parsed[item] === undefined) {
+				throw new UnixArgumentError({ error: 'required', args: [item] })
+			}
+		}
+
+		// validate types
+		for (let type of ['float', 'number']) {
+			for (let arg of (opts[type] || [])) {
+				let argValues = Array.isArray(parsed[arg]) ? parsed[arg] : [parsed[arg]]
+				argValues.forEach(e => {
+					if (Number.isNaN(e)) {
+						throw new UnixArgumentError({ error: 'type', args: [arg], expected: type })
+					}
+				})
+			}
+		}
+		for (let arg of (opts.integer || [])) {
+			let argValues = Array.isArray(parsed[arg]) ? parsed[arg] : [parsed[arg]]
+			argValues.forEach(e => {
+				if (Number.isNaN(e) || e !== Math.trunc(e)) {
+					throw new UnixArgumentError({ error: 'type', args: [arg], expected: 'integer' })
+				}
+			})
+		}
+
+		// validate nargs (arguments that need a certain number of values)
+		for (let arg in (opts.narg || {})) {
+			if (parsed[arg] !== undefined && opts.narg[arg] > 1 && (!Array.isArray(parsed[arg]) || parsed[arg].length !== opts.narg[arg])) {
+				throw new UnixArgumentError({ error: 'narg', args: [arg], expected: opts.narg[arg] })
+			}
+		}
+
+		return parsed
+	}
+
+	/**
+	 * Transform a channel ID or a channel mention into a channel ID
+	 * @param {String} arg A channel ID or channel mention
+	 * @returns {String|Boolean} A channel ID, or false if no ID was found
+	 */
+	static _coerceChannel (arg) {
+		if (Array.isArray(arg)) return arg.map(UnixArguments._coerceChannel)
+		let match = /^<#(\d+)>$|^(\d+)$/.exec(arg.trim())
+		if (!match) {
+			return false
+		}
+		return match[1] || match[2]
+	}
+
+	/**
+	 * Transform a user ID or a user mention into a user ID
+	 * @param {String} arg A user ID or user mention
+	 * @returns {String|Boolean} A user ID, or false if no ID was found
+	 */
+	static _coerceUser (arg) {
+		if (Array.isArray(arg)) return arg.map(UnixArguments._coerceUser)
+		let match = /^<@!?(\d+)>$|^(\d+)$/.exec(arg.trim())
+		if (!match) {
+			return false
+		}
+		return match[1] || match[2]
+	}
+}
+
+module.exports = UnixArguments

--- a/src/utility/index.js
+++ b/src/utility/index.js
@@ -1,4 +1,5 @@
 module.exports = {
 	Arguments: require('./arguments/Arguments'),
-	Types: require('./arguments/Types')
+	Types: require('./arguments/Types'),
+	UnixArguments: require('./arguments/UnixArguments')
 }


### PR DESCRIPTION
This adds a parser for UNIX-style command arguments.

Commands can now export an object with parser options. Any commands *not* exporting this object will continue to use the old parser.

Usage information (aka `exports.help.args`) can be automatically generated from these options, and will be displayed if the command is invoked with the `--help` argument.

This also adds two test/debug commands using the new parser.