### PR TITLE
Let users assign programming language roles to themselves

### DIFF
--- a/commands/moderation/set-languages.js
+++ b/commands/moderation/set-languages.js
@@ -1,0 +1,94 @@
+const Language = require('../../src/models/Language.js')
+const UnixArguments = require('../../src/utility/arguments/UnixArguments.js')
+const UnixHelpError = require('../../src/errors/UnixHelpError.js')
+
+exports.pre = async (client, message) => {
+	console.log('Command "set-languages" run by ' + message.author.username)
+}
+
+exports.run = async (client, message, args, pre) => {
+	let authorMember = await message.guild.fetchMember(message.author)
+	if (!authorMember.hasPermission('ADMINISTRATOR')) {
+		return message.reply('you are not authorized to use this command.')
+	}
+	if (!(args.create || args.delete || args.list)) {
+		throw new UnixHelpError()
+	}
+
+	let availableLanguages = await Language.find({ guildId: message.guild.id }).exec()
+
+	// delete any languages that don't have roles anymore
+	let deletions = []
+	for (let i = availableLanguages.length - 1; i >= 0; --i) {
+		if (!message.guild.roles.find(e => e.name === availableLanguages[i].name)) {
+			deletions.push(availableLanguages[i].delete())
+			availableLanguages.splice(i, 1)
+		}
+	}
+	await Promise.all(deletions)
+
+	let createdLanguages = []
+	let createdRoles = []
+	let removedLanguages = []
+
+	// create languages
+	for (let lang of Array.from(new Set(args.add || []).values())) {
+		if (availableLanguages.find(e => e.name === lang)) {
+			// language already exists
+			continue
+		}
+		if (!message.guild.roles.find(e => e.name === lang)) {
+			await message.guild.createRole({ name: lang, permissions: [] })
+			createdRoles.push(lang)
+		}
+		let language = new Language({ name: lang, guildId: message.guild.id })
+		await language.save()
+		createdLanguages.push(lang)
+	}
+	// remove languages
+	for (let lang of Array.from(new Set(args.delete || []).values())) {
+		let language = availableLanguages.find(e => e.name === lang)
+		if (!language) {
+			// language doesn't exist
+			continue
+		}
+		await language.delete()
+		removedLanguages.push(lang)
+	}
+
+	let text = `${message.author}\n`
+	if (!(createdRoles.length || createdLanguages.length || removedLanguages.length)) {
+		text += `No roles or languages modified.`
+	} else {
+		if (createdRoles.length) {
+			text += `Created role${createdRoles.length === 1 ? '' : 's'} ${createdRoles.map(e => `"${e}"`).join(', ')}.\n`
+		}
+		if (createdLanguages.length) {
+			text += `Created language${createdLanguages.length === 1 ? '' : 's'} ${createdLanguages.map(e => `"${e}"`).join(', ')}.\n`
+		}
+		if (removedLanguages.length) {
+			text += `Removed language${removedLanguages.length === 1 ? '' : 's'} ${removedLanguages.map(e => `"${e}"`).join(', ')}.\n`
+		}
+	}
+	return message.channel.send(text)
+}
+
+exports.post = async (client, message, result) => {
+	console.log('Command "set-languages" complete!')
+}
+
+exports.yargsOpts = {
+	alias: {
+		create: ['c', 'add', 'a'],
+		delete: ['d', 'remove', 'r'],
+		help: ['h']
+	},
+	array: ['create', 'delete']
+}
+
+exports.help = {
+	name: ['set-languages'],
+	group: 'moderation',
+	description: 'Command to manage the available programming langage roles.',
+	args: UnixArguments.generateUsage(exports.yargsOpts)
+}

--- a/commands/utility/languages.js
+++ b/commands/utility/languages.js
@@ -1,0 +1,128 @@
+const Language = require('../../src/models/Language.js')
+const UnixArguments = require('../../src/utility/arguments/UnixArguments.js')
+const UnixHelpError = require('../../src/errors/UnixHelpError.js')
+
+exports.pre = async (client, message) => {
+	console.log('Command "languages" run by ' + message.author.username)
+}
+
+exports.run = async (client, message, args, pre) => {
+	if (!(args.add || args.remove || args.list)) {
+		throw new UnixHelpError()
+	}
+
+	let availableLanguages = await Language.find({ guildId: message.guild.id }).exec()
+
+	// remove duplicates
+	let languagesToAdd = Array.from(new Set(args.add || []).values())
+	let languagesToRemove = Array.from(new Set(args.remove || []).values())
+
+	// remove items that are in both lists
+	for (let i = languagesToAdd.length - 1; i >= 0; --i) {
+		let removeIndex = languagesToRemove.indexOf(languagesToAdd[i])
+		if (removeIndex !== -1) {
+			languagesToAdd.splice(i, 1)
+			languagesToRemove.splice(removeIndex, 1)
+		}
+	}
+
+	let rolesToAdd = []
+	let rolesToRemove = []
+	let notAvailable = false
+
+	for (let lang of languagesToAdd) {
+		if (!availableLanguages.find(e => e.name === lang)) {
+			notAvailable = true
+			continue
+		}
+		let role = message.guild.roles.find(e => e.name === lang)
+		if (!role) {
+			notAvailable = true
+			continue
+		}
+		rolesToAdd.push(role)
+	}
+	for (let lang of languagesToRemove) {
+		if (!availableLanguages.find(e => e.name === lang)) {
+			notAvailable = true
+			continue
+		}
+		let role = message.guild.roles.find(e => e.name === lang)
+		if (!role) {
+			notAvailable = true
+			continue
+		}
+		rolesToRemove.push(role)
+	}
+
+	// if an unavailable language was chosen and/or the available languages need to be listed, delete any languages that don't have roles anymore
+	if (notAvailable || args.list) {
+		let deletions = []
+		for (let i = availableLanguages.length - 1; i >= 0; --i) {
+			if (!message.guild.roles.find(e => e.name === availableLanguages[i].name)) {
+				deletions.push(availableLanguages[i].delete())
+				availableLanguages.splice(i, 1)
+			}
+		}
+		await Promise.all(deletions)
+	}
+
+	let member = await message.guild.fetchMember(message.author)
+
+	// ignore roles that the user wants to add, but already has / wants to remove, but already doesn't have
+	for (let i = rolesToAdd.length - 1; i >= 0; --i) {
+		if (member.roles.has(rolesToAdd[i].id)) {
+			rolesToAdd.splice(i, 1)
+		}
+	}
+	for (let i = rolesToRemove.length - 1; i >= 0; --i) {
+		if (!member.roles.has(rolesToRemove[i].id)) {
+			rolesToRemove.splice(i, 1)
+		}
+	}
+
+	await member.addRoles(rolesToAdd)
+	await member.removeRoles(rolesToRemove)
+
+	let text = `${message.author},`
+	if (rolesToAdd.length) {
+		text += ` added ${rolesToAdd.map(e => `"${e.name}"`).join(', ')}`
+	}
+	if (rolesToAdd.length && rolesToRemove.length) {
+		text += ` and`
+	}
+	if (rolesToRemove.length) {
+		text += ` removed ${rolesToRemove.map(e => `"${e.name}"`).join(', ')}`
+	}
+	if (rolesToAdd.length || rolesToRemove.length) {
+		text += `.\n`
+	} else {
+		text += ` no roles modified.\n`
+	}
+	if (notAvailable || args.list) {
+		text += `Available languages:\n${availableLanguages.length ? availableLanguages.map(e => `• ${e.name}`).sort().join('\n') : 'None'}`
+	}
+	return message.channel.send(text)
+}
+
+exports.post = async (client, message, result) => {
+	console.log('Command "languages" complete!')
+}
+
+exports.yargsOpts = {
+	alias: {
+		add: ['a'],
+		help: ['h'],
+		list: ['l'],
+		remove: ['r']
+	},
+	array: ['add', 'remove'],
+	boolean: ['list']
+}
+
+exports.help = {
+	name: ['languages'],
+	group: 'utility',
+	description: 'Command to manage your programming language roles.',
+	args: UnixArguments.generateUsage(exports.yargsOpts)
+}

--- a/config-example.json
+++ b/config-example.json
@@ -1,5 +1,6 @@
 {
 	"token": "bot-token",
+	"database": "mongodb://localhost:27017/db-community-bot",
 	"prefix": "?",
 	"procName": "Discord_Bots",
 	"authors": ["Mundane"]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/Mundayne/Discord_Bot#readme",
   "dependencies": {
     "discord.js": "^11.4.0",
+    "mongoose": "^5.3.0",
     "yargs-parser": "^10.1.0"
   },
   "devDependencies": {

--- a/src/classes/Handler.js
+++ b/src/classes/Handler.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose')
 const FS = require('fs')
 const { Arguments, UnixArguments } = require('../utility')
 const { ArgumentError, UnixArgumentError, UnixHelpError } = require('../errors')
@@ -41,9 +42,16 @@ class Handler {
 		console.info(`Done! ${count.commands} commands loaded across ${count.groups} groups.`)
 	}
 
-	start () {
-		this.client.login(Config.token)
-		process.title = Config.procName
+	async start () {
+		try {
+			await mongoose.connect(Config.database, { useNewUrlParser: true })
+			await this.client.login(Config.token)
+			process.title = Config.procName
+		} catch (err) {
+			console.error('Fatal error while starting bot:')
+			console.error(err)
+			process.exit(1)
+		}
 	}
 
 	async message (_self, message) {

--- a/src/models/Language.js
+++ b/src/models/Language.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose')
+
+const schema = mongoose.Schema({
+	name: String,
+	guildId: String
+})
+
+module.exports = mongoose.model('Language', schema, 'languages')

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	Language: require('./Language')
+}


### PR DESCRIPTION
Users can use the "languages" command to manage their programming language roles.

Mods can use the "set-languages" command to manage what languages can be chosen by users.

This implements [this project card](https://github.com/Mundayne/Discord_Bot/projects/1#card-13415171).