### PR TITLE
Add support for positional arguments to Unix-style parser

### DIFF
--- a/commands/dev/testunix.js
+++ b/commands/dev/testunix.js
@@ -28,10 +28,13 @@ exports.post = async (client, message, result) => {
 	Passing an object with a "description" property as a default value will treat it not as a literal value, but a description of a default value
 	that's computed at runtime. It is the command implementer's responsibility to actually compute and set that value, as the parser cannot do that.
 
-	Additional supported fields are "required" and "exclusive".
+	Additional supported fields are "required", "exclusive" and "positional".
 	- "required" is an array of strings listing all arguments that must be present. Any argument not listed is assumed to be optional.
 	- "exclusive" is an array of arrays of strings, listing groups of mutually exclusive arguments. Listing one or more arguments of a
 	group as required will mean the entire group is required.
+	- "positional" is an object with the format { args: [{ name: String, type: String, required: Boolean|Number|Object|String }], required: Number }.
+	(The "default" field is optional.) It is used to define any positional arguments the command takes. Positional arguments will be available using
+	the name given, but they will also still be available via the "_" array.
 
 	Lastly, the --help argument is reserved. If it (or any alias of it) is used, the command is not executed, and its usage information is
 	displayed instead.

--- a/commands/dev/unixargs.js
+++ b/commands/dev/unixargs.js
@@ -12,7 +12,7 @@ exports.run = async (client, message, args, pre) => {
 		return message.channel.send('Error:```\n' + err + '\n```')
 	}
 	delete parsed.opts
-	return message.channel.send('Options:```\n' + JSON.stringify(JSON.parse(args.opts), null, '\t') + '\n```\nParsed:```\n' + JSON.stringify(parsed, null, '\t') + '\n```')
+	return message.channel.send('Options:```\n' + JSON.stringify(JSON.parse(args.opts), null, '\t') + '\n```\nUsage:```\n' + UnixArguments.generateUsage(JSON.parse(args.opts)) + '\n```\nParsed:```\n' + JSON.stringify(parsed, null, '\t') + '\n```')
 }
 
 exports.post = async (client, message, result) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord_bots",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A bot made for the /r/Discord_Bots Discord server.",
   "main": "index.js",
   "scripts": {

--- a/src/utility/arguments/UnixArguments.js
+++ b/src/utility/arguments/UnixArguments.js
@@ -38,7 +38,7 @@ class UnixArguments {
 			if (!argString) continue
 			if (opts.default[arg].description) {
 				argStringsMap.set(arg, `${argString}={${opts.default[arg].description}}`)
-			} else if (argString.includes(':string')) {
+			} else if (typeof opts.default[arg] === 'string') {
 				argStringsMap.set(arg, `${argString}="${opts.default[arg]}"`)
 			} else {
 				argStringsMap.set(arg, `${argString}=${opts.default[arg]}`)
@@ -79,7 +79,7 @@ class UnixArguments {
 			if (e.default !== undefined) {
 				if (e.default.description) {
 					argString += `={${e.default.description}}`
-				} else if (e.type === 'string') {
+				} else if (typeof e.default === 'string') {
 					argString += `="${e.default}"`
 				} else {
 					argString += `=${e.default}`


### PR DESCRIPTION
Now positional arguments can be shown in the usage information.

In commands, their types are validated and they can now also be accessed using their names (similar to the old parser).