### PR TITLE
Don't display dev commands in the help

### DIFF
--- a/commands/general/help.js
+++ b/commands/general/help.js
@@ -20,6 +20,7 @@ exports.run = async (client, message, args, pre) => {
 	} else {
 		embed.setTitle('Command List')
 		for (let group in client.commands) {
+			if (group === 'dev') continue
 			let uniqueCommands = Array.from(new Set(Object.values(client.commands[group])).values())
 			let text = ''
 			for (let command of uniqueCommands) {


### PR DESCRIPTION
This PR will hide the dev commands in the help.

This affects only the command list, the individual help pages of a dev command can still be seen if you know about the command.