### PR TITLE
Make arguments of language commands case-insensitive

### DIFF
--- a/commands/moderation/set-languages.js
+++ b/commands/moderation/set-languages.js
@@ -24,7 +24,7 @@ exports.run = async (client, message, args, pre) => {
 
 	// create languages
 	for (let lang of Array.from(new Set(args.add || []).values())) {
-		if (availableLanguages.find(e => e.name === lang)) {
+		if (availableLanguages.find(e => e.name.toLowerCase() === lang.toLowerCase())) {
 			// language already exists
 			continue
 		}
@@ -38,13 +38,14 @@ exports.run = async (client, message, args, pre) => {
 	}
 	// remove languages
 	for (let lang of Array.from(new Set(args.delete || []).values())) {
-		let language = availableLanguages.find(e => e.name === lang)
+		let language = availableLanguages.find(e => e.name.toLowerCase() === lang.toLowerCase())
 		if (!language) {
 			// language doesn't exist
 			continue
 		}
+		let actualName = language.name
 		await language.delete()
-		removedLanguages.push(lang)
+		removedLanguages.push(actualName)
 	}
 
 	let text = `${message.author}\n`

--- a/commands/utility/languages.js
+++ b/commands/utility/languages.js
@@ -8,9 +8,13 @@ exports.run = async (client, message, args, pre) => {
 
 	let availableLanguages = await Language.find({ guildId: message.guild.id }).exec()
 
+	// convert languages to lowercase
+	args.add = (args.add || []).map(e => e.toLowerCase())
+	args.remove = (args.remove || []).map(e => e.toLowerCase())
+
 	// remove duplicates
-	let languagesToAdd = Array.from(new Set(args.add || []).values())
-	let languagesToRemove = Array.from(new Set(args.remove || []).values())
+	let languagesToAdd = Array.from(new Set(args.add).values())
+	let languagesToRemove = Array.from(new Set(args.remove).values())
 
 	// remove items that are in both lists
 	for (let i = languagesToAdd.length - 1; i >= 0; --i) {
@@ -26,11 +30,11 @@ exports.run = async (client, message, args, pre) => {
 	let notAvailable = false
 
 	for (let lang of languagesToAdd) {
-		if (!availableLanguages.find(e => e.name === lang)) {
+		if (!availableLanguages.find(e => e.name.toLowerCase() === lang)) {
 			notAvailable = true
 			continue
 		}
-		let role = message.guild.roles.find(e => e.name === lang)
+		let role = message.guild.roles.find(e => e.name.toLowerCase() === lang)
 		if (!role) {
 			notAvailable = true
 			continue
@@ -38,11 +42,11 @@ exports.run = async (client, message, args, pre) => {
 		rolesToAdd.push(role)
 	}
 	for (let lang of languagesToRemove) {
-		if (!availableLanguages.find(e => e.name === lang)) {
+		if (!availableLanguages.find(e => e.name.toLowerCase() === lang)) {
 			notAvailable = true
 			continue
 		}
-		let role = message.guild.roles.find(e => e.name === lang)
+		let role = message.guild.roles.find(e => e.name.toLowerCase() === lang)
 		if (!role) {
 			notAvailable = true
 			continue


### PR DESCRIPTION
This makes the ?languages command not care about the capitalization of the language arguments. (So `--add javascript` will successfully add the "JavaScript" role, for example.)

The ?set-languages command now also does not care about capitalization when deleting roles, and will not create a role that has the same name as another when both are converted to lowercase. However, languages and roles are still created with the specified capitalization, and that is their official name.