### PR TITLE
Move help embed generation to own class, show help embed with --help

### DIFF
--- a/commands/general/help.js
+++ b/commands/general/help.js
@@ -1,33 +1,13 @@
-const Discord = require('discord.js')
-
 exports.run = async (handler, message, args, pre) => {
-	let botMember = await message.guild.fetchMember(message.client.user)
-	let embed = new Discord.RichEmbed()
-	embed.setColor(botMember.displayColor || null)
 	if (args.command) {
-		let cmds = {}
-		Object.values(handler.commands).forEach(group => { cmds = { ...cmds, ...group } })
-		if (!cmds.hasOwnProperty(args.command)) {
+		let embed = await handler.help.commandHelp(message.guild, args.command)
+		if (!embed) {
 			await message.channel.send(`Command "${args.command}" not found.`)
 			return
 		}
-		let commandObj = cmds[args.command]
-		embed.setTitle(commandObj.help.name[0])
-		embed.addField('Description', commandObj.help.description)
-		if (commandObj.help.name.length > 1) embed.addField('Aliases', commandObj.help.name.slice(1).join(', '))
-		embed.addField('Usage', `${handler.prefix}${args.command} ${commandObj.help.args}`)
 		await message.channel.send(embed)
 	} else {
-		embed.setTitle('Command List')
-		for (let group in handler.commands) {
-			if (group === 'dev') continue
-			let uniqueCommands = Array.from(new Set(Object.values(handler.commands[group])).values())
-			let text = ''
-			for (let command of uniqueCommands) {
-				text += `${handler.prefix}${command.help.name[0]} - ${command.help.description}\n`
-			}
-			embed.addField(group[0].toUpperCase() + group.slice(1), text)
-		}
+		let embed = await handler.help.commandList(message.guild)
 		await message.channel.send(embed)
 	}
 }

--- a/src/classes/Handler.js
+++ b/src/classes/Handler.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose')
 const fs = require('fs')
 const { Arguments, UnixArguments } = require('../utility')
 const { ArgumentError, InsufficientPermissionsError, PreCheckFailedError, UnixArgumentError, UnixHelpError } = require('../errors')
+const Help = require('./Help')
 const CONFIG = require('../../config')
 
 class Handler {
@@ -9,6 +10,7 @@ class Handler {
 		this.commands = { }
 		this.prefix = CONFIG.prefix
 		this.client = client
+		this.help = new Help(this)
 
 		client.on('ready', () => this.ready())
 		client.on('message', message => this.message(message))
@@ -114,7 +116,8 @@ class Handler {
 				message.reply(e.message).then(m => m.delete(8000)).catch(console.error)
 			} else if (e instanceof UnixHelpError) {
 				console.log(`Sending usage information for command "${name}"`)
-				message.channel.send(`${'```'}\nUsage:\n${this.prefix}${name} ${command.help.args}\n${'```'}`).catch(console.error)
+				let embed = await this.help.commandHelp(message.guild, name)
+				message.channel.send(embed).catch(console.error)
 			} else {
 				console.error(`Error during command "${name}":`)
 				console.error(e)

--- a/src/classes/Help.js
+++ b/src/classes/Help.js
@@ -1,0 +1,43 @@
+const Discord = require('discord.js')
+
+class Help {
+	constructor (handler) {
+		this.handler = handler
+	}
+
+	async commandHelp (guild, command) {
+		let cmds = {}
+		Object.values(this.handler.commands).forEach(group => { cmds = { ...cmds, ...group } })
+		if (!cmds.hasOwnProperty(command)) {
+			return false
+		}
+		let commandObj = cmds[command]
+		let embed = await this._baseEmbed(guild)
+		embed.setTitle(commandObj.help.name[0])
+		embed.addField('Description', commandObj.help.description)
+		if (commandObj.help.name.length > 1) embed.addField('Aliases', commandObj.help.name.slice(1).join(', '))
+		embed.addField('Usage', `${this.handler.prefix}${command} ${commandObj.help.args}`)
+		return embed
+	}
+
+	async commandList (guild) {
+		let embed = await this._baseEmbed(guild)
+		embed.setTitle('Command List')
+		for (let group in this.handler.commands) {
+			if (group === 'dev') continue
+			let uniqueCommands = Array.from(new Set(Object.values(this.handler.commands[group])).values())
+			let text = ''
+			for (let command of uniqueCommands) {
+				text += `${this.handler.prefix}${command.help.name[0]} - ${command.help.description}\n`
+			}
+			embed.addField(group[0].toUpperCase() + group.slice(1), text)
+		}
+		return embed
+	}
+
+	async _baseEmbed (guild) {
+		let botMember = await guild.fetchMember(guild.client.user)
+		return new Discord.RichEmbed().setColor(botMember.displayColor || null)
+	}
+}
+module.exports = Help

--- a/src/classes/index.js
+++ b/src/classes/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-	Handler: require('./Handler')
+	Handler: require('./Handler'),
+	Help: require('./Help')
 }


### PR DESCRIPTION
All the logic of creating the help embeds is now in a dedicated class, with the help command just calling it from there.

`?help command` and `?command --help` now both show the same message.