### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: xenial
+language: node_js
+node_js:
+  - 11
+cache: npm
+
+install: npm install
+script:
+  - npx eslint --max-warnings=0 .


### PR DESCRIPTION
This just adds a simple `travis.yml` that will just `eslint` the source. To really use it, the owner of this repository has to sign in to https://travis-ci.com and enable the integration for this repository.