### PR TITLE
Remove the ~24 day limit on setting reminders

### DIFF
--- a/commands/utility/remindme.js
+++ b/commands/utility/remindme.js
@@ -6,15 +6,15 @@ exports.run = async (handler, message, args, pre) => {
 	}
 
 	// get total milliseconds
-	var ms = ((args.days ? args.days : 0) * 86400000) + ((args.hours ? args.hours : 0) * 3600000) + ((args.minutes ? args.minutes : 0) * 60000) + ((args.seconds ? args.seconds : 0) * 1000)
+	let ms = ((args.days ? args.days : 0) * 86400000) + ((args.hours ? args.hours : 0) * 3600000) + ((args.minutes ? args.minutes : 0) * 60000) + ((args.seconds ? args.seconds : 0) * 1000)
 
 	// get future date
-	var reminderDate = Date.now() + ms
+	let reminderDate = Date.now() + ms
 
 	await message.channel.send(`Set a reminder for ${new Date(reminderDate).toISOString().replace(/T/, ' ').replace(/\..+/, '')}${args.reason ? ` for \`${args.reason}\`` : ''}.`)
 
 	// send the reminder to the database
-	var reminder = new Reminder({ userId: message.author.id, reminderDate: reminderDate, reminderReason: args.reason })
+	let reminder = new Reminder({ userId: message.author.id, reminderDate: reminderDate, reminderReason: args.reason })
 	await reminder.save()
 
 	// ensure new reminder is loaded if it's due soon

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord_bots",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A bot made for the /r/Discord_Bots Discord server.",
   "main": "index.js",
   "scripts": {

--- a/src/classes/ReminderManager.js
+++ b/src/classes/ReminderManager.js
@@ -1,0 +1,37 @@
+const logger = require('winston').loggers.get('default')
+const Reminder = require('../../src/models/Reminder.js')
+const { LOAD_INTERVAL } = require('../../src/constants/reminders.js')
+
+class ReminderManager {
+	constructor (handler) {
+		this.handler = handler
+		this.loadedReminders = new Set()
+	}
+
+	/**
+	 * Loads all reminders due in the near future
+	 * @returns {Promise<void>}
+	 */
+	async loadReminders () {
+		let reminders = await Reminder.find({ reminderDate: { $lt: Date.now() + LOAD_INTERVAL } })
+		for (let reminder of reminders) {
+			if (this.loadedReminders.has(String(reminder._id))) continue
+			this.loadedReminders.add(String(reminder._id))
+			let reminderTimeout = reminder.reminderDate - Date.now()
+			setTimeout(async () => {
+				try {
+					var user = await this.handler.client.fetchUser(reminder.userId)
+					await user.send(`Reminding you${reminder.reminderReason ? ` for \`${reminder.reminderReason}\`` : ''}!`)
+					await reminder.delete()
+					this.loadedReminders.delete(String(reminder._id))
+				} catch (err) {
+					logger.error(`Something happened with a reminder.`)
+					logger.error(err)
+				}
+				// If the reminder time <= 0, remind the user immediately
+			}, reminderTimeout > 0 ? reminderTimeout : 1)
+		}
+	}
+}
+
+module.exports = ReminderManager

--- a/src/classes/ReminderManager.js
+++ b/src/classes/ReminderManager.js
@@ -20,7 +20,7 @@ class ReminderManager {
 			let reminderTimeout = reminder.reminderDate - Date.now()
 			setTimeout(async () => {
 				try {
-					var user = await this.handler.client.fetchUser(reminder.userId)
+					let user = await this.handler.client.fetchUser(reminder.userId)
 					await user.send(`Reminding you${reminder.reminderReason ? ` for \`${reminder.reminderReason}\`` : ''}!`)
 					await reminder.delete()
 					this.loadedReminders.delete(String(reminder._id))

--- a/src/constants/reminders.js
+++ b/src/constants/reminders.js
@@ -1,0 +1,3 @@
+module.exports = {
+	LOAD_INTERVAL: 60 * 60 * 1000 // 1 hour
+}


### PR DESCRIPTION
Reminders are now just saved in the database, and only loaded into `setTimeout`s shortly before they're due.