### PR TITLE
Add self-role command "helper"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+.idea/
 package-lock.json
 config.json

--- a/commands/utility/helper.js
+++ b/commands/utility/helper.js
@@ -1,0 +1,41 @@
+exports.run = async (handler, message, args, pre) => {
+	let member = await message.guild.fetchMember(message.author)
+
+	let helperRole = await message.guild.roles.find(role => role.name === 'Helper')
+	let developerRole = await message.guild.roles.find(role => role.name === 'Developer')
+
+	let hadRole = false
+	let isDeveloper = false
+
+	if (member.roles.has(developerRole.id)) {
+		if (member.roles.has(helperRole.id)) {
+			await member.removeRole(helperRole)
+			hadRole = false
+		} else if (!member.roles.has(helperRole.id)) {
+			await member.addRole(helperRole)
+			hadRole = true
+		}
+
+		isDeveloper = true
+	}
+
+	if (!isDeveloper) {
+		message.reply('you are not a developer. Please apply to be a developer before adding the helper role!')
+	} else if (hadRole) {
+		message.reply(`added the Helper role!`)
+	} else if (!hadRole) {
+		message.reply('removed the Helper role!')
+	}
+}
+
+exports.yargsOpts = {
+	alias: {
+		help: ['h']
+	}
+}
+
+exports.help = {
+	name: ['helper'],
+	group: 'utility',
+	description: 'Toggle the helper role if you are a developer.'
+}


### PR DESCRIPTION
If the user possesses the Developer role, then they can use the ?helper toggle to add or remove the helper role at will. The command does not work and warns if a user is not a developer yet, and suggests for them to apply.

Third time's gotta be the charm.