### PR TITLE
Remove unneeded fetching for members that are always cached

### DIFF
--- a/commands/general/help.js
+++ b/commands/general/help.js
@@ -7,8 +7,7 @@ exports.run = async (handler, message, args, pre) => {
 		}
 		await message.channel.send(embed)
 	} else {
-		let member = message.member || await message.guild.members.fetch(message.author)
-		let embed = await handler.help.commandList(message.guild, member.hasPermission('ADMINISTRATOR'))
+		let embed = await handler.help.commandList(message.guild, message.member.hasPermission('ADMINISTRATOR'))
 		await message.channel.send(embed)
 	}
 }

--- a/commands/general/wizard.js
+++ b/commands/general/wizard.js
@@ -5,16 +5,15 @@ const { PENDING } = require('../../src/constants/devApplications.js').COLORS
 exports.run = async (handler, message, args, pre) => {
 	let responseMessage
 	let existingApplication = await DevApplication.findOne({ userId: message.author.id, guildId: message.guild.id }).exec()
-	let member = message.member || await message.guild.members.fetch(message.author)
 
 	if (existingApplication) {
 		responseMessage = 'You\'ve already requested the developer role; please be patient as The Council processes your request.'
-	} else if (member.roles.cache.some(r => r.name.toLowerCase() === 'developer')) {
+	} else if (message.member.roles.cache.some(r => r.name.toLowerCase() === 'developer')) {
 		responseMessage = 'You\'re already a developer.'
 	} else {
 		let modLog = message.guild.channels.cache.find(c => c.name === 'mod-log')
 		let applicationMessage = new Discord.MessageEmbed()
-			.setAuthor(member.displayName, message.author.displayAvatarURL())
+			.setAuthor(message.member.displayName, message.author.displayAvatarURL())
 			.setTitle('Developer Role Application')
 			.addField('User ID:', message.member.id)
 			.addField('GitHub URL:', args.github)

--- a/commands/utility/helper.js
+++ b/commands/utility/helper.js
@@ -1,15 +1,13 @@
 exports.run = async (handler, message, args, pre) => {
-	let member = message.member || await message.guild.members.fetch(message.author)
-
 	let helperRole = await message.guild.roles.cache.find(role => role.name.toLowerCase() === 'helper')
 	let developerRole = await message.guild.roles.cache.find(role => role.name.toLowerCase() === 'developer')
 
-	if (member.roles.cache.has(developerRole.id)) {
-		if (member.roles.cache.has(helperRole.id)) {
-			await member.roles.remove(helperRole)
+	if (message.member.roles.cache.has(developerRole.id)) {
+		if (message.member.roles.cache.has(helperRole.id)) {
+			await message.member.roles.remove(helperRole)
 			await message.reply('removed the Helper role!')
 		} else {
-			await member.roles.add(helperRole)
+			await message.member.roles.add(helperRole)
 			await message.reply(`added the Helper role!`)
 		}
 	} else {

--- a/commands/utility/languages.js
+++ b/commands/utility/languages.js
@@ -66,26 +66,24 @@ exports.run = async (handler, message, args, pre) => {
 		await Promise.all(deletions)
 	}
 
-	let member = message.member || await message.guild.members.fetch(message.author)
-
 	// ignore roles that the user wants to add, but already has / wants to remove, but already doesn't have
 	for (let i = rolesToAdd.length - 1; i >= 0; --i) {
-		if (member.roles.cache.has(rolesToAdd[i].id)) {
+		if (message.member.roles.cache.has(rolesToAdd[i].id)) {
 			rolesToAdd.splice(i, 1)
 		}
 	}
 	for (let i = rolesToRemove.length - 1; i >= 0; --i) {
-		if (!member.roles.cache.has(rolesToRemove[i].id)) {
+		if (!message.member.roles.cache.has(rolesToRemove[i].id)) {
 			rolesToRemove.splice(i, 1)
 		}
 	}
 
-	let targetRoles = member.roles.cache
+	let targetRoles = message.member.roles.cache
 	for (let role of rolesToAdd) {
 		targetRoles.set(role.id, role)
 	}
 	targetRoles.sweep(e => rolesToRemove.some(f => e.id === f.id))
-	await member.roles.set(targetRoles)
+	await message.member.roles.set(targetRoles)
 
 	let text = `${message.author},`
 	if (rolesToAdd.length) {

--- a/commands/utility/userinfo.js
+++ b/commands/utility/userinfo.js
@@ -21,7 +21,7 @@ exports.run = async (handler, message, args, pre) => {
 	}
 
 	if (!member) {
-		member = message.member || await message.guild.members.fetch(message.author)
+		member = message.member
 	}
 
 	const embed = new Discord.MessageEmbed()

--- a/src/classes/Handler.js
+++ b/src/classes/Handler.js
@@ -49,8 +49,7 @@ class Handler {
 						if (typeof command.pre !== 'function') {
 							if (group === 'moderation') {
 								command.pre = async (handler, message) => {
-									let authorMember = await message.guild.members.fetch(message.author)
-									if (!authorMember.hasPermission('ADMINISTRATOR')) {
+									if (!message.member.hasPermission('ADMINISTRATOR')) {
 										throw new InsufficientPermissionsError()
 									}
 								}

--- a/src/classes/Help.js
+++ b/src/classes/Help.js
@@ -37,8 +37,7 @@ class Help {
 	}
 
 	async _baseEmbed (guild) {
-		let botMember = guild.me || await guild.members.fetch(guild.client.user)
-		return new Discord.MessageEmbed().setColor(botMember.displayColor || null)
+		return new Discord.MessageEmbed().setColor(guild.me.displayColor || null)
 	}
 }
 module.exports = Help


### PR DESCRIPTION
Turns out I misunderstood how discord.js v12 handles member caching a little bit, so some of the things I added in 4900503b4a383b8584070e1048b7a17df55f00bd were unnecessary.

`message.member` is guaranteed to be cached for new messages, so there's no need to ever fetch it in that case. (It still needs to be fetched for messages that aren't new, however.)

Similarly, `guild.me` is always available.